### PR TITLE
Web link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ### Hi, I'm Kaya 👋
 
-I’m an iOS developer, writer and public speaker. I'm the creator of [We Read Too](wereadtoo.com), a book resource app that features books for kids and teens with main characters of colors written by Black, Latinx, Asian and Indigenous authors. I currently work as a Senior Software Engineer at Calm. 
+I’m an iOS developer, writer and public speaker. I'm the creator of [We Read Too](https://wereadtoo.com), a book resource app that features books for kids and teens with main characters of colors written by Black, Latinx, Asian and Indigenous authors. I currently work as a Senior Software Engineer at Calm. 
 
 - 📱  I’m currently working on Calm, We Read Too and Irth App.
 - 🤓 I’m currently learning SwiftUI.
 - 💬  Ask me about iOS development, Swift, accessibility.
-- 📫  How to reach me: kaya@hey.com or Twitter [@kthomas901](twitter.com/kthomas901)
+- 📫  How to reach me: kaya@hey.com or Twitter [@kthomas901](https://twitter.com/kthomas901)
 - 😄  Pronouns: she/her
 - 🚴🏽‍♀️  Fun fact: I love cycling and I'm currently building up my mileage to eventually be able to do my first gran fondo!


### PR DESCRIPTION
Hey Kaya,

Love the design and art in your GitHub readme! Full disclosure, I feel super weird creating a PR for your personal readme but it's still early days for this new feature so I hope it's ok.

I ran into an issue though where a 404 error was displayed when clicking on the link for **We Read Too**. The markdown was interpreting the link as a directory that didn't exist within the repo instead of the actual URL. I noticed the link to your Twitter was also doing the same thing.

I just added the `https://` prefix to both links and it seems to have fixed it.

Love the positivity and the awareness that you've created with your **We Read Too** project!